### PR TITLE
Parts of config.toml are not localized in Hindi.

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -429,8 +429,8 @@ language_alternatives = ["en"]
 
 [languages.hi]
 title = "Kubernetes"
-description = "Production-Grade Container Orchestration"
-languageName = "Hindi"
+description = "localized text"
+languageName = "हिंदी Hindi"
 weight = 11
 contentDir = "content/hi"
 languagedirection = "ltr"


### PR DESCRIPTION
Changes made as follows as in issue description.

Proposed Solution:
Localize [langauges.hi] section as following

[languages.hi]
title = "Kubernetes"
description = "<localized text>"
languageName = "हिंदी Hindi"
weight = 11
contentDir = "content/hi"
languagedirection = "ltr"