### PR TITLE
Fixed: The CNCF hyperlink on the HOME page

### DIFF
--- a/content/en/docs/home/_index.md
+++ b/content/en/docs/home/_index.md
@@ -19,7 +19,7 @@ menu:
 description: >
   Kubernetes is an open source container orchestration engine for automating deployment, scaling, and management of containerized applications. The open source project is hosted by the Cloud Native Computing Foundation.
 overview: >
-  Kubernetes is an open source container orchestration engine for automating deployment, scaling, and management of containerized applications. The open source project is hosted by the Cloud Native Computing Foundation (<a href="https://www.cncf.io/about">CNCF</a>).
+  Kubernetes is an open source container orchestration engine for automating deployment, scaling, and management of containerized applications. The open source project is hosted by the Cloud Native Computing Foundation ([CNCF](https://www.cncf.io/about)).
 cards:
 - name: concepts
   title: "Understand Kubernetes"


### PR DESCRIPTION
Fixed The CNCF hyperlink on the HOME page is overwritten and cannot be clicked.
Fixed issue- #33034
 
